### PR TITLE
Fix Generate Certificate curl example response

### DIFF
--- a/source/includes/_generate.md
+++ b/source/includes/_generate.md
@@ -170,19 +170,15 @@ curl "https://example.com/api/v1/data" \
 
 ```json
 {
-  "data": [
-    {
-      "id": "67fc3def-bbfb-4953-83f8-4ab0682ad676",
-      "name": "/example-certificate",
-      "type": "certificate",
-      "value": {
-        "ca": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
-        "certificate": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
-        "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
-      }, 
-      "version_created_at": "2017-01-01T04:07:18Z"
-    }
-  ]
+  "id": "67fc3def-bbfb-4953-83f8-4ab0682ad676",
+  "name": "/example-certificate",
+  "type": "certificate",
+  "value": {
+    "ca": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+    "certificate": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+    "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+  }, 
+  "version_created_at": "2017-01-01T04:07:18Z"
 }
 ```
 


### PR DESCRIPTION
Generate certificate docs suggest the response nests the generated certificate in a data tag, when in actuality, the server returns the certificate at the top level.

This has been confirmed via the Credhub slack channel.

Signed-off-by: Rebecca Chin <rchin@pivotal.io>