### PR TITLE
Precise search term matching in Find by Partial Name

### DIFF
--- a/source/includes/_find.md
+++ b/source/includes/_find.md
@@ -37,7 +37,7 @@ curl "https://example.com/api/v1/data?name-like=password" \
 }
 ```
 
-This request retrieves a list of stored credential names which contain the search.
+This request retrieves a list of stored credential names which contain the search term.
 
 ### HTTP Request
 
@@ -47,7 +47,7 @@ This request retrieves a list of stored credential names which contain the searc
 
 Parameter | Default | Required | Type | Description
 --------- | --------- | --------- | --------- | -----------
-name-like | none | true | string | Search term to match against stored credential names
+name-like | none | true | string | Search term to match against stored credential names (lower case substring matching)
 
 ## Find by Path
 

--- a/source/includes/_find.md
+++ b/source/includes/_find.md
@@ -47,7 +47,7 @@ This request retrieves a list of stored credential names which contain the searc
 
 Parameter | Default | Required | Type | Description
 --------- | --------- | --------- | --------- | -----------
-name-like | none | true | string | Search term to match against stored credential names (lower case substring matching)
+name-like | none | true | string | Search term to match against stored credential names (case insensitive substring matching)
 
 ## Find by Path
 


### PR DESCRIPTION
This PR precises that the `name-like` term does not support regular expression or other wild card syntax.

Following my analysis that only lower case substring matching is supported:

https://github.com/cloudfoundry-incubator/credhub/blob/6e18d1ad11fec1bc3055224a14de787b5bb0642e/src/main/java/org/cloudfoundry/credhub/data/CredentialVersionDataService.java#L107-L109

```java
  public List<FindCredentialResult> findContainingName(String name) {
    return findMatchingName("%" + name + "%");
}
```

https://github.com/cloudfoundry-incubator/credhub/blob/6e18d1ad11fec1bc3055224a14de787b5bb0642e/src/main/java/org/cloudfoundry/credhub/data/CredentialVersionDataService.java#L242

```java
   private List<FindCredentialResult> findMatchingName(String nameLike) {
     final List<FindCredentialResult> credentialResults = jdbcTemplate.query(
         " select name.name, credential_version.version_created_at from ("
             + "   select"
             + "     max(version_created_at) as version_created_at,"
             + "     credential_uuid"
             + "   from credential_version group by credential_uuid"
             + " ) as credential_version inner join ("
             + "   select * from credential"
             + "     where lower(name) like lower(?)"
             + " ) as name"
             + " on credential_version.credential_uuid = name.uuid"
             + " order by version_created_at desc",
         new Object[]{nameLike},
         (rowSet, rowNum) -> {
           final Instant versionCreatedAt = Instant
               .ofEpochMilli(rowSet.getLong("version_created_at"));
           final String name = rowSet.getString("name");
           return new FindCredentialResult(versionCreatedAt, name);
         }
     );
     return credentialResults;
 }
```


Mysql document precises that LIKE only supports Simple pattern matching 

https://dev.mysql.com/doc/refman/8.0/en/string-comparison-functions.html#operator_like
https://dev.mysql.com/doc/refman/8.0/en/pattern-matching.html
> The other type of pattern matching provided by MySQL uses extended regular expressions. When you test for a match for this type of pattern, use the REGEXP_LIKE() function (or the REGEXP or RLIKE operators, which are synonyms for REGEXP_LIKE()). 

/CC @psycofdj 
